### PR TITLE
Add IQL pipeline helper

### DIFF
--- a/procgen/run_iql_pipeline.sh
+++ b/procgen/run_iql_pipeline.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+# Default locations for dataset and checkpoints
+DATASET_DIR="${DATASET_DIR:-$(pwd)/data/expert_data_1M}"
+CHECKPOINT_DIR="${CHECKPOINT_DIR:-$(pwd)/checkpoints/iql}"
+
+# Step 1: Download the Procgen expert dataset (1M transitions)
+python download.py --download_folder "$DATASET_DIR" --category_name 1M_E --clear_archives_after_unpacking
+
+# Step 2: Create a temporary config based on final/iql.json with paths filled in
+CONFIG_DIR="configs/offline/final"
+ORIG_CONFIG="$CONFIG_DIR/iql.json"
+PIPELINE_CONFIG=$(mktemp /tmp/iql_pipeline.XXXXXX.json)
+python - "$ORIG_CONFIG" "$PIPELINE_CONFIG" "$DATASET_DIR" "$CHECKPOINT_DIR" <<'PY'
+import json, sys
+orig, dest, data_dir, ckpt_dir = sys.argv[1:]
+with open(orig) as f:
+    cfg = json.load(f)
+cfg['grid']['dataset'] = [data_dir]
+cfg['grid']['save_path'] = [ckpt_dir]
+with open(dest, 'w') as f:
+    json.dump(cfg, f, indent=4)
+PY
+
+# Step 3: Generate training commands for all environments
+python -m train_scripts.make_cmd \
+  --base_config offline \
+  --dir final \
+  --checkpoint \
+  --grid_config iql_pipeline \
+  --num_trials 1 \
+  --new_line \
+  --module_name offline.train_offline_agent > pipeline_commands.txt
+
+# Step 4: Run training sequentially
+while read -r cmd; do
+  [ -n "$cmd" ] || continue
+  echo "Running: $cmd"
+  eval "$cmd"
+done < pipeline_commands.txt
+
+# Step 5: Evaluate each trained model
+while read -r cmd; do
+  [ -n "$cmd" ] || continue
+  eval_cmd=${cmd/offline.train_offline_agent/offline.evaluate_offline_agent}
+  echo "Evaluating: $eval_cmd"
+  eval "$eval_cmd"
+done < pipeline_commands.txt


### PR DESCRIPTION
## Summary
- add a runnable script to download Procgen data, train and evaluate IQL agents

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'procgen')*

------
https://chatgpt.com/codex/tasks/task_e_684c47ed89a4832eb2e7aee71ff203e5