### PR TITLE
Fix pipeline commands

### DIFF
--- a/procgen/run_iql_pipeline.sh
+++ b/procgen/run_iql_pipeline.sh
@@ -43,7 +43,6 @@ python -m train_scripts.make_cmd \
   --checkpoint \
   --grid_config iql_pipeline \
   --num_trials 1 \
-  --new_line \
   --module_name offline.train_offline_agent > pipeline_commands.txt
 
 # Step 4: Run training sequentially


### PR DESCRIPTION
## Summary
- fix pipeline generation in `run_iql_pipeline.sh`
- ensure newline at end of file

## Testing
- `bash run_iql_pipeline.sh` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684c78342ccc832eac17bf29b6138461