### PR TITLE
Limit memory to 42GB

### DIFF
--- a/procgen/configs/offline/default.json
+++ b/procgen/configs/offline/default.json
@@ -17,7 +17,7 @@
     "eval_eps": 0.001,
     "eval_freq": 10,
     "ckpt_freq": 10,
-    "dataset_size": 1000000,
+    "dataset_size": 150000,
     "early_stop": false,
 
     "target_update_freq": 1000,

--- a/procgen/configs/offline/final/bct.json
+++ b/procgen/configs/offline/final/bct.json
@@ -4,7 +4,7 @@
             "bct"
         ],
         "dataset_size": [
-            1000000
+            150000
         ],
         "env_name": [
             "bigfish", "bossfight", "caveflyer", "chaser", "climber", "coinrun", "dodgeball", "fruitbot", "heist", "jumper", "leaper", "ninja", "maze", "miner", "plunder", "starpilot"

--- a/procgen/configs/offline/final/cql.json
+++ b/procgen/configs/offline/final/cql.json
@@ -4,7 +4,7 @@
             "cql"
         ],
         "dataset_size": [
-            1000000
+            150000
         ],
         "env_name": [
             "bigfish", "bossfight", "caveflyer", "chaser", "climber", "coinrun", "dodgeball", "fruitbot", "heist", "jumper", "leaper", "ninja", "maze", "miner", "plunder", "starpilot"

--- a/procgen/configs/offline/final/dt.json
+++ b/procgen/configs/offline/final/dt.json
@@ -4,7 +4,7 @@
             "dt"
         ],
         "dataset_size": [
-            1000000
+            150000
         ],
         "env_name": [
             "bigfish", "bossfight", "caveflyer", "chaser", "climber", "coinrun", "dodgeball", "fruitbot", "heist", "jumper", "leaper", "ninja", "maze", "miner", "plunder", "starpilot"

--- a/procgen/configs/offline/final/iql.json
+++ b/procgen/configs/offline/final/iql.json
@@ -4,7 +4,7 @@
             "iql"
         ],
         "dataset_size": [
-            1000000
+            150000
         ],
         "env_name": [
             "bigfish", "bossfight", "caveflyer", "chaser", "climber", "coinrun", "dodgeball", "fruitbot", "heist", "jumper", "leaper", "ninja", "maze", "miner", "plunder", "starpilot"

--- a/procgen/configs/offline/final/iql_pipeline.json
+++ b/procgen/configs/offline/final/iql_pipeline.json
@@ -4,7 +4,7 @@
             "iql"
         ],
         "dataset_size": [
-            1000000
+            150000
         ],
         "env_name": [
             "bigfish",

--- a/procgen/configs/offline/grids/bc.json
+++ b/procgen/configs/offline/grids/bc.json
@@ -4,7 +4,7 @@
             "bc"
         ],
         "dataset_size": [
-            1000000
+            150000
         ],
         "env_name": [
             "bigfish", "bossfight", "caveflyer", "chaser", "climber", "coinrun", "dodgeball", "fruitbot", "heist", "jumper", "leaper", "ninja", "maze", "miner", "plunder", "starpilot"

--- a/procgen/configs/offline/grids/bcq.json
+++ b/procgen/configs/offline/grids/bcq.json
@@ -4,7 +4,7 @@
             "bcq"
         ],
         "dataset_size": [
-            1000000
+            150000
         ],
         "env_name": [
             "bigfish", "bossfight", "caveflyer", "chaser", "climber", "coinrun", "dodgeball", "fruitbot", "heist", "jumper", "leaper", "ninja", "maze", "miner", "plunder", "starpilot"

--- a/procgen/configs/offline/grids/bct.json
+++ b/procgen/configs/offline/grids/bct.json
@@ -4,7 +4,7 @@
             "bct"
         ],
         "dataset_size": [
-            1000000
+            150000
         ],
         "env_name": [
             "bigfish", "bossfight", "caveflyer", "chaser", "climber", "coinrun", "dodgeball", "fruitbot", "heist", "jumper", "leaper", "ninja", "maze", "miner", "plunder", "starpilot"

--- a/procgen/configs/offline/grids/cql.json
+++ b/procgen/configs/offline/grids/cql.json
@@ -4,7 +4,7 @@
             "cql"
         ],
         "dataset_size": [
-            1000000
+            150000
         ],
         "env_name": [
             "bigfish", "bossfight", "caveflyer", "chaser", "climber", "coinrun", "dodgeball", "fruitbot", "heist", "jumper", "leaper", "ninja", "maze", "miner", "plunder", "starpilot"

--- a/procgen/configs/offline/grids/dt.json
+++ b/procgen/configs/offline/grids/dt.json
@@ -4,7 +4,7 @@
             "dt"
         ],
         "dataset_size": [
-            1000000
+            150000
         ],
         "env_name": [
             "bigfish", "bossfight", "caveflyer", "chaser", "climber", "coinrun", "dodgeball", "fruitbot", "heist", "jumper", "leaper", "ninja", "maze", "miner", "plunder", "starpilot"

--- a/procgen/configs/offline/grids/iql.json
+++ b/procgen/configs/offline/grids/iql.json
@@ -4,7 +4,7 @@
             "iql"
         ],
         "dataset_size": [
-            1000000
+            150000
         ],
         "env_name": [
             "bigfish", "bossfight", "caveflyer", "chaser", "climber", "coinrun", "dodgeball", "fruitbot", "heist", "jumper", "leaper", "ninja", "maze", "miner", "plunder", "starpilot"

--- a/procgen/offline/arguments.py
+++ b/procgen/offline/arguments.py
@@ -8,61 +8,159 @@ import argparse
 from utils.utils import str2bool
 
 parser = argparse.ArgumentParser(description="Train offline agents")
-parser.add_argument("--algo", type=str, default="bc", choices=["bc", "cql", "dt", "bct", "bcq", "offlinedqn", "iql", "xql"], help="Algorithm to train")
-parser.add_argument("--dataset", type=str, default="data/dataset.hdf5", help="Path to dataset")
-parser.add_argument("--percentile", type=float, default=1.0, help="percentile for top% training")
-parser.add_argument("--dataset_size", type=int, default=1000000, help="Size of dataset")
-parser.add_argument("--early_stop", type=str2bool, default=False, help="Use early stopping")
+parser.add_argument(
+    "--algo",
+    type=str,
+    default="bc",
+    choices=["bc", "cql", "dt", "bct", "bcq", "offlinedqn", "iql", "xql"],
+    help="Algorithm to train",
+)
+parser.add_argument(
+    "--dataset", type=str, default="data/dataset.hdf5", help="Path to dataset"
+)
+parser.add_argument(
+    "--percentile", type=float, default=1.0, help="percentile for top% training"
+)
+parser.add_argument("--dataset_size", type=int, default=150000, help="Size of dataset")
+parser.add_argument(
+    "--early_stop", type=str2bool, default=False, help="Use early stopping"
+)
 
 # Model
 parser.add_argument("--lr", type=float, default=1e-3, help="Learning rate")
 parser.add_argument("--batch_size", type=int, default=64, help="Batch size")
 parser.add_argument("--epochs", type=int, default=10, help="Number of epochs")
 parser.add_argument("--hidden_size", type=int, default=64, help="Size of hidden layers")
-parser.add_argument("--agent_model", type=str, default="dqn", choices=["dqn", "bcq", "pporesnetbase", "pporesnet20", "bcqresnetbase"], help="Agent model")
-parser.add_argument("--save_path", type=str, default="data/bc.pt", help="Path to save model")
+parser.add_argument(
+    "--agent_model",
+    type=str,
+    default="dqn",
+    choices=["dqn", "bcq", "pporesnetbase", "pporesnet20", "bcqresnetbase"],
+    help="Agent model",
+)
+parser.add_argument(
+    "--save_path", type=str, default="data/bc.pt", help="Path to save model"
+)
 parser.add_argument("--resume", type=str2bool, default=False, help="Resume training")
-parser.add_argument("--deterministic", type=str2bool, default=False, help="Sample actions deterministically")
+parser.add_argument(
+    "--deterministic",
+    type=str2bool,
+    default=False,
+    help="Sample actions deterministically",
+)
 parser.add_argument("--xpid", type=str, default=None, help="experiment name")
-parser.add_argument("--eval_eps", type=float, default=0.001, help="epsilon for evaluation")
+parser.add_argument(
+    "--eval_eps", type=float, default=0.001, help="epsilon for evaluation"
+)
 
 # Environment
-parser.add_argument("--env_name", type=str, default="bigfish", help="Name of environment")
+parser.add_argument(
+    "--env_name", type=str, default="bigfish", help="Name of environment"
+)
 parser.add_argument("--seed", type=int, default=88, help="experiment seed")
-parser.add_argument("--num_levels", type=int, default=200, help="number of training levels used in procgen")
-parser.add_argument("--distribution_mode", type=str, default="easy", help="Distribution mode of procgen levels")
+parser.add_argument(
+    "--num_levels",
+    type=int,
+    default=200,
+    help="number of training levels used in procgen",
+)
+parser.add_argument(
+    "--distribution_mode",
+    type=str,
+    default="easy",
+    help="Distribution mode of procgen levels",
+)
 parser.add_argument("--eval_freq", type=int, default=10, help="frequency for eval")
-parser.add_argument("--ckpt_freq", type=int, default=10, help="frequency for checkpointing")
+parser.add_argument(
+    "--ckpt_freq", type=int, default=10, help="frequency for checkpointing"
+)
 
 # DDQN
-parser.add_argument("--target_update_freq", type=int, default=1000, help="frequency for target network update")
+parser.add_argument(
+    "--target_update_freq",
+    type=int,
+    default=1000,
+    help="frequency for target network update",
+)
 parser.add_argument("--gamma", type=float, default=0.99, help="discount factor")
 parser.add_argument("--tau", type=float, default=0.005, help="soft update factor")
-parser.add_argument("--buffer_size", type=int, default=1000000, help="size of replay buffer")
+parser.add_argument(
+    "--buffer_size", type=int, default=150000, help="size of replay buffer"
+)
 parser.add_argument("--eps_start", type=float, default=1.0, help="epsilon start value")
 parser.add_argument("--eps_end", type=float, default=0.01, help="epsilon end value")
 parser.add_argument("--eps_decay", type=int, default=1000000, help="epsilon decay rate")
-parser.add_argument("--perform_polyak_update", type=str2bool, default=False, help="whether to use polyak average or directly copy model weights")
+parser.add_argument(
+    "--perform_polyak_update",
+    type=str2bool,
+    default=False,
+    help="whether to use polyak average or directly copy model weights",
+)
 
 # CQL
 parser.add_argument("--cql_alpha", type=float, default=1.0, help="CQL Loss alpha")
 
 # BCQ
-parser.add_argument("--bcq_threshold", type=float, default=0.3, help="BCQ threshold for action selection")
+parser.add_argument(
+    "--bcq_threshold",
+    type=float,
+    default=0.3,
+    help="BCQ threshold for action selection",
+)
 
 # IQL
-parser.add_argument("--iql_temperature", type=float, default=0.1, help="IQL temperature for action selection")
-parser.add_argument("--iql_expectile", type=float, default=0.8, help="IQL Expectile Loss")
+parser.add_argument(
+    "--iql_temperature",
+    type=float,
+    default=0.1,
+    help="IQL temperature for action selection",
+)
+parser.add_argument(
+    "--iql_expectile", type=float, default=0.8, help="IQL Expectile Loss"
+)
 
 # DT
-parser.add_argument("--dt_context_length", type=int, default=128, help="context length for the agent")
-parser.add_argument("--grad_norm_clip", type=float, default=0.1, help="gradient norm clip for the agent")
-parser.add_argument("--weight_decay", type=float, default=0.01, help="weight decay only applied on matmul weights")
-parser.add_argument("--lr_decay", type=str2bool, default=True, help="learning rate decay with linear warmup followed by cosine decay to 10% of original")
+parser.add_argument(
+    "--dt_context_length", type=int, default=128, help="context length for the agent"
+)
+parser.add_argument(
+    "--grad_norm_clip", type=float, default=0.1, help="gradient norm clip for the agent"
+)
+parser.add_argument(
+    "--weight_decay",
+    type=float,
+    default=0.01,
+    help="weight decay only applied on matmul weights",
+)
+parser.add_argument(
+    "--lr_decay",
+    type=str2bool,
+    default=True,
+    help="learning rate decay with linear warmup followed by cosine decay to 10% of original",
+)
 parser.add_argument("--warmup_tokens", type=int, default=10000, help="warmup tokens")
-parser.add_argument("--dt_rtg_noise_prob", type=float, default=0.0, help="noise probability for RTGs")
-parser.add_argument("--dt_eval_ret", type=int, default=0, help="evaluation return to go. if > 0, then eval rtg = args.dt_eval_ret * max_return in the dataset")
+parser.add_argument(
+    "--dt_rtg_noise_prob", type=float, default=0.0, help="noise probability for RTGs"
+)
+parser.add_argument(
+    "--dt_eval_ret",
+    type=int,
+    default=0,
+    help="evaluation return to go. if > 0, then eval rtg = args.dt_eval_ret * max_return in the dataset",
+)
 
 # Single Level Training
-parser.add_argument("--capacity_type", type=str, default="transitions", choices=["transitions", "episodes"], help="capacity type")
-parser.add_argument("--threshold_metric", type=str, default="median", choices=["percentile", "median"], help="threshold metric")
+parser.add_argument(
+    "--capacity_type",
+    type=str,
+    default="transitions",
+    choices=["transitions", "episodes"],
+    help="capacity type",
+)
+parser.add_argument(
+    "--threshold_metric",
+    type=str,
+    default="median",
+    choices=["percentile", "median"],
+    help="threshold metric",
+)

--- a/procgen/train_scripts/slurm.py
+++ b/procgen/train_scripts/slurm.py
@@ -31,7 +31,7 @@ def arg2str(k, v):
 
 
 class LaunchExperiments:
-    def __init__(self, module_name: str="offline"):
+    def __init__(self, module_name: str = "offline"):
         self.module_name = module_name
 
     def launch_experiment_and_remotenv(self, experiment_args):
@@ -46,17 +46,28 @@ class LaunchExperiments:
             args = itertools.chain(*[arg2str(k, v) for k, v in experiment_args.items()])
 
             if self.module_name == "offline":
-                subprocess.call([python_exec, "-m", "offline.train_offline_agent"] + list(args))
+                subprocess.call(
+                    [python_exec, "-m", "offline.train_offline_agent"] + list(args)
+                )
             elif self.module_name == "eval":
-                subprocess.call([python_exec, "-m", "offline.evaluate_offline_agent"] + list(args))
+                subprocess.call(
+                    [python_exec, "-m", "offline.evaluate_offline_agent"] + list(args)
+                )
             elif self.module_name == "single":
-                subprocess.call([python_exec, "-m", "offline.single_level_train_offline_agent"] + list(args))
+                subprocess.call(
+                    [python_exec, "-m", "offline.single_level_train_offline_agent"]
+                    + list(args)
+                )
             elif self.module_name == "data_collection":
-                subprocess.call([python_exec, "-m", "online.data_collector"] + list(args))
+                subprocess.call(
+                    [python_exec, "-m", "online.data_collector"] + list(args)
+                )
             else:
                 subprocess.call([python_exec, "-m", "online.trainer"] + list(args))
 
-        experiment_process = mp.Process(target=launch_experiment, args=[experiment_args])
+        experiment_process = mp.Process(
+            target=launch_experiment, args=[experiment_args]
+        )
         self.process = experiment_process
         experiment_process.start()
         experiment_process.join()
@@ -67,7 +78,9 @@ class LaunchExperiments:
     def checkpoint(self, experiment_args) -> submitit.helpers.DelayedSubmission:
         self.process.terminate()
         experiment_args["checkpoint"] = True
-        return submitit.helpers.DelayedSubmission(LaunchExperiments(self.module_name), experiment_args)
+        return submitit.helpers.DelayedSubmission(
+            LaunchExperiments(self.module_name), experiment_args
+        )
 
 
 def main(argv):
@@ -108,7 +121,7 @@ def main(argv):
         ntasks_per_node=1,
         # job setup
         job_name=FLAGS.name,
-        mem="512GB",
+        mem="42GB",
         cpus_per_task=10,
         gpus_per_node=1,
         constraint="volta32gb",
@@ -118,7 +131,9 @@ def main(argv):
     print("\nAbout to submit", len(all_args), "jobs")
 
     if not FLAGS.debug:
-        job = executor.map_array(LaunchExperiments(module_name=FLAGS.module_name), all_args)
+        job = executor.map_array(
+            LaunchExperiments(module_name=FLAGS.module_name), all_args
+        )
 
         for j in job:
             print("Submitted with job id: ", j.job_id)


### PR DESCRIPTION
## Summary
- tighten default offline dataset and buffer sizes
- lower Slurm memory request to 42GB
- apply the smaller dataset size across offline configs

## Testing
- `ruff check .` *(fails: many style issues, existing)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'procgen')*

------
https://chatgpt.com/codex/tasks/task_e_684c9d7e3448832ea5dcbe83d93a6b52